### PR TITLE
Refresh token utilility

### DIFF
--- a/ray_kube/utils.py
+++ b/ray_kube/utils.py
@@ -1,0 +1,13 @@
+import subprocess
+
+
+def refresh_token():
+    """
+    Dummy call to kubectl to refresh the kubernetes oicd token.
+    See https://github.com/kr8s-org/kr8s/issues/125
+    """
+    subprocess.run(
+        ["kubectl", "cluster-info"],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )


### PR DESCRIPTION
Adds a `refresh_token` util that will make a dummy `kubectl` call which will refresh OICD token. 
See https://github.com/kr8s-org/kr8s/issues/125