### PR TITLE
add set env method

### DIFF
--- a/ray_kube/cluster.py
+++ b/ray_kube/cluster.py
@@ -93,6 +93,13 @@ class KubernetesRayCluster:
         self.head.set_env_from_secret(secret)
         self.worker.set_env_from_secret(secret)
 
+    def set_env(self, env: dict):
+        """
+        Set the environment variables in the head and worker deployments
+        """
+        self.head.set_env(env)
+        self.worker.set_env(env)
+
     def wait(self, timeout: Optional[float] = None):
         count = 0
         while not self.is_ready():

--- a/ray_kube/resources/deployments.py
+++ b/ray_kube/resources/deployments.py
@@ -48,6 +48,12 @@ class RayDeployment(Deployment):
             container["envFrom"] = []
         container["envFrom"].append(ref)
 
+    def set_env(self, env: dict):
+        container = self["spec"]["template"]["spec"]["containers"][0]
+        container["env"] = []
+        for key, value in env.items():
+            container["env"].append(dict(name=key, value=value))
+
     def set_image(self):
         container = self["spec"]["template"]["spec"]["containers"][0]
         container["image"] = self.image


### PR DESCRIPTION
Adds `set_env` method to `Deployments` and main `KubernetesRayCluster` object that will take a dictionary and set the `env` property for both head and worker deployments. closes #5 